### PR TITLE
Add PastPage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,114 +65,116 @@ https://www.youtube.com/watch?v=ekXS3y_s8k8
 ## Browser Extensions for OSINT
 
 **Chrome Extension** -
-| Name |      | Description                | 
-| :-------- | :------- | :------------------------- | 
+| Name |      | Description                |
+| :-------- | :------- | :------------------------- |
 |[Ubikron](https://www.ubikron.com/)||Chrome extension that speaks to a server (in the cloud or in your server room) and keeps track of sites you’ve browsed to. It saves screenshots of the sites as well as all the body text. |
-|[Vortimo OSINT-tool](https://chrome.google.com/webstore/detail/vortimo-osint-tool/mnakbpdnkedaegeiaoakkjafhoidklnf)||Helps in getting more information about name, phone number, email, and many more. | 
-|[Hunchly 2.0](https://chrome.google.com/webstore/detail/hunchly-20/amfnegileeghgikpggcebehdepknalbf)|| Helps in capture and organize online data for your investigations.| 
-|[Selection Search](https://chrome.google.com/webstore/detail/selection-search/gipnlpdeieaidmmeaichnddnmjmcakoe)|| Helps you in searching for the selected text in multiple search engines| 
-|[Email Tracker](https://chrome.google.com/webstore/detail/email-tracker/bnompdfnhdbgdaoanapncknhmckenfog)||Helps you in finding out if your email has been read| 
-|[Geotrack Email Tracking with Geolocation](https://chrome.google.com/webstore/detail/geotrack-email-tracking-w/ciajnfanflofkddjdanppgnlpkkdclln)|| Helps you in Email tracking with geolocation right in Gmail, with real-time statistics| 
-|[Gotanda](https://chrome.google.com/webstore/detail/gotanda/jbmdcdfnnpenkgliplbglfpninigbiml)|| Helpful for searching OSINT information from some IOC in web page.(IP,Domain,URL,SNS...etc)| 
-|[Map Switcher](https://chrome.google.com/webstore/detail/map-switcher/fanpjcbgdinjeknjikpfnldfpnnpkelb?hl=en)|| Helpful in switching between different map services with a single click| 
-|[Magnifying Glass](https://chrome.google.com/webstore/detail/magnifying-glass/elhdjgjjmodgmhkokebhegekjooiaofm)|| Helpful in viewing a zoomed image within its radius, without disturbing the rest of the page.| 
-|[EXIF Viewer Pro](https://chrome.google.com/webstore/detail/exif-viewer-pro/mmbhfeiddhndihdjeganjggkmjapkffm)|| Helpful in quickly accessing exif data of any image you view.| 
-|[Fake news debunker by InVID & WeVerify](https://chrome.google.com/webstore/detail/fake-news-debunker-by-inv/mhccpoafgdgbhnjfhkcmgknndkeenfhe?hl=en)|| Helpful for journalists, fact-checkers and human right defenders in fact-checking and debunking tasks on social networks.| 
-|[TinEye Reverse Image Search](https://chrome.google.com/webstore/detail/tineye-reverse-image-sear/haebnnbpedcbhciplfhjjkbafijpncjl)|| Helpful in reverse image search and other features offered by Tineye| 
-|[Search by Image](https://chrome.google.com/webstore/detail/search-by-image/cnojnbdhbhnkbcieeekonklommdnndci)|| Helpful in reverse image search with support for various search engines, such as Google, Bing, Yandex, Baidu and TinEye.| 
-|[PhotOSINT](https://chrome.google.com/webstore/detail/photosint/gonhdjmkgfkokhkflfhkbiagbmoolhcd)|| Helpful in scanning images for exif metadata while browsing| 
-|[Resemble AI Deepfake Detector](https://chromewebstore.google.com/detail/resemble-ai-deepfake-dete/ligejojghpehckjpfldljdcckgcbngle)|| Helpful for scanning web images, videos, and audio for AI-generated or manipulated media with verdicts and confidence scores.| 
-|[Distill](https://chrome.google.com/webstore/detail/distill-web-monitor/inlikjemeeknofckkjolnjbpehgadgge?hl=en-US)|| Extension allows you to passively monitor changes on social pages.| 
-|[Visualping](https://chrome.google.com/webstore/detail/visualping/pemhgklkefakciniebenbfclihhmmfcd)|| A simple service for monitoring websites for changes.| 
-|[Fetcher](https://chrome.google.com/webstore/detail/fetcher/hcjoaaeflhldlbmadokknllgaagbonla/)|| Extension fetches from your favourite websites, and combines them into one| 
-|[FireShot](https://chrome.google.com/webstore/detail/take-webpage-screenshots/mcbpblocgmgfnpjjppndjkmgjaogfceg?hl=en-US)|| Allows you to quickly take a screenshot of a web page in full screen mode.| 
-|[Nimbus Screenshot & Screen Video Recorder](https://chrome.google.com/webstore/detail/nimbus-screenshot-screen/bpconcjcammlapcogcnnelfmaeghhagj)|| Helpful for taking screenshots and video recording web pages.| 
-|[Go Back in Time](https://chrome.google.com/webstore/detail/go-back-in-time/hgdahcpipmgehmaaankiglanlgljlakj)|| Allows you to view an archived version of a web page.| 
-|[The Wayback Machine](https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak)|| Extension of the Internet Archive| 
-|[Web Cache Viewer](https://chrome.google.com/webstore/detail/web-cache-viewer/pbkloffickinnlnmefmjmjbacohecpbd)|| lets you right-click on any link or page to view the Wayback Machine or Google Cache versions of that page.| 
-|[Blockchain.info](https://chrome.google.com/webstore/detail/blockchaininfo-address-se/aipmpbhchlkopmpoaipbelfpniojcnkb)|| Helps to find info on bitcoin address.| 
-|[Blockchair](https://chrome.google.com/webstore/detail/blockchair/fhhkkooikehnkaodebbfnkinedlllcfk)|| Block explorer and anonymous crypto portfolio tracker for Bitcoin, Ethereum, and others in your browser.| 
+|[Vortimo OSINT-tool](https://chrome.google.com/webstore/detail/vortimo-osint-tool/mnakbpdnkedaegeiaoakkjafhoidklnf)||Helps in getting more information about name, phone number, email, and many more. |
+|[Hunchly 2.0](https://chrome.google.com/webstore/detail/hunchly-20/amfnegileeghgikpggcebehdepknalbf)|| Helps in capture and organize online data for your investigations.|
+|[Selection Search](https://chrome.google.com/webstore/detail/selection-search/gipnlpdeieaidmmeaichnddnmjmcakoe)|| Helps you in searching for the selected text in multiple search engines|
+|[Email Tracker](https://chrome.google.com/webstore/detail/email-tracker/bnompdfnhdbgdaoanapncknhmckenfog)||Helps you in finding out if your email has been read|
+|[Geotrack Email Tracking with Geolocation](https://chrome.google.com/webstore/detail/geotrack-email-tracking-w/ciajnfanflofkddjdanppgnlpkkdclln)|| Helps you in Email tracking with geolocation right in Gmail, with real-time statistics|
+|[Gotanda](https://chrome.google.com/webstore/detail/gotanda/jbmdcdfnnpenkgliplbglfpninigbiml)|| Helpful for searching OSINT information from some IOC in web page.(IP,Domain,URL,SNS...etc)|
+|[Map Switcher](https://chrome.google.com/webstore/detail/map-switcher/fanpjcbgdinjeknjikpfnldfpnnpkelb?hl=en)|| Helpful in switching between different map services with a single click|
+|[Magnifying Glass](https://chrome.google.com/webstore/detail/magnifying-glass/elhdjgjjmodgmhkokebhegekjooiaofm)|| Helpful in viewing a zoomed image within its radius, without disturbing the rest of the page.|
+|[EXIF Viewer Pro](https://chrome.google.com/webstore/detail/exif-viewer-pro/mmbhfeiddhndihdjeganjggkmjapkffm)|| Helpful in quickly accessing exif data of any image you view.|
+|[Fake news debunker by InVID & WeVerify](https://chrome.google.com/webstore/detail/fake-news-debunker-by-inv/mhccpoafgdgbhnjfhkcmgknndkeenfhe?hl=en)|| Helpful for journalists, fact-checkers and human right defenders in fact-checking and debunking tasks on social networks.|
+|[TinEye Reverse Image Search](https://chrome.google.com/webstore/detail/tineye-reverse-image-sear/haebnnbpedcbhciplfhjjkbafijpncjl)|| Helpful in reverse image search and other features offered by Tineye|
+|[Search by Image](https://chrome.google.com/webstore/detail/search-by-image/cnojnbdhbhnkbcieeekonklommdnndci)|| Helpful in reverse image search with support for various search engines, such as Google, Bing, Yandex, Baidu and TinEye.|
+|[PhotOSINT](https://chrome.google.com/webstore/detail/photosint/gonhdjmkgfkokhkflfhkbiagbmoolhcd)|| Helpful in scanning images for exif metadata while browsing|
+|[Resemble AI Deepfake Detector](https://chromewebstore.google.com/detail/resemble-ai-deepfake-dete/ligejojghpehckjpfldljdcckgcbngle)|| Helpful for scanning web images, videos, and audio for AI-generated or manipulated media with verdicts and confidence scores.|
+|[Distill](https://chrome.google.com/webstore/detail/distill-web-monitor/inlikjemeeknofckkjolnjbpehgadgge?hl=en-US)|| Extension allows you to passively monitor changes on social pages.|
+|[Visualping](https://chrome.google.com/webstore/detail/visualping/pemhgklkefakciniebenbfclihhmmfcd)|| A simple service for monitoring websites for changes.|
+|[Fetcher](https://chrome.google.com/webstore/detail/fetcher/hcjoaaeflhldlbmadokknllgaagbonla/)|| Extension fetches from your favourite websites, and combines them into one|
+|[FireShot](https://chrome.google.com/webstore/detail/take-webpage-screenshots/mcbpblocgmgfnpjjppndjkmgjaogfceg?hl=en-US)|| Allows you to quickly take a screenshot of a web page in full screen mode.|
+|[Nimbus Screenshot & Screen Video Recorder](https://chrome.google.com/webstore/detail/nimbus-screenshot-screen/bpconcjcammlapcogcnnelfmaeghhagj)|| Helpful for taking screenshots and video recording web pages.|
+|[Go Back in Time](https://chrome.google.com/webstore/detail/go-back-in-time/hgdahcpipmgehmaaankiglanlgljlakj)|| Allows you to view an archived version of a web page.|
+|[PastPage](https://chromewebstore.google.com/detail/pastpage-query-10+-web-ar/icpegbecignmplpkjjcegmjmfadpcpoo)|| Helps recover broken or changed pages by querying the Wayback Machine and other web archives in parallel.|
+|[The Wayback Machine](https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak)|| Extension of the Internet Archive|
+|[Web Cache Viewer](https://chrome.google.com/webstore/detail/web-cache-viewer/pbkloffickinnlnmefmjmjbacohecpbd)|| lets you right-click on any link or page to view the Wayback Machine or Google Cache versions of that page.|
+|[Blockchain.info](https://chrome.google.com/webstore/detail/blockchaininfo-address-se/aipmpbhchlkopmpoaipbelfpniojcnkb)|| Helps to find info on bitcoin address.|
+|[Blockchair](https://chrome.google.com/webstore/detail/blockchair/fhhkkooikehnkaodebbfnkinedlllcfk)|| Block explorer and anonymous crypto portfolio tracker for Bitcoin, Ethereum, and others in your browser.|
 |[Breadcrumbs Blockchain Investigate](https://chrome.google.com/webstore/detail/breadcrumbs-blockchain-in/dlnalaneihafdkdcekejdekiclgdghka)|| Investigation tool to get more details on any Ethereum address’s activity.|
-|[Instant Data Scraper](https://chrome.google.com/webstore/detail/instant-data-scraper/ofaokhiedipichpaobibbnahnkdoiiah)|| An automatic data scraping tool for any website.| 
-|[Data Scraper](https://chrome.google.com/webstore/detail/data-scraper-easy-web-scr/nndknepjnldbdbepjfgmncbggmopgden)|| Extracts data out of HTML web pages and imports it into Microsoft Excel spreadsheets.| 
-|[Email extract](https://chrome.google.com/webstore/detail/email-extract/ejecpjcajdpbjbmlcojcohgenjngflac)|| Helps in finding email addresses on the pages you visit.| 
-|[Hunter](https://chrome.google.com/webstore/detail/hunter-email-finder-exten/hgmhmanijnjhaffoampdlllchpolkdnj)|| Extension to find an email address on any website with one click.| 
+|[Instant Data Scraper](https://chrome.google.com/webstore/detail/instant-data-scraper/ofaokhiedipichpaobibbnahnkdoiiah)|| An automatic data scraping tool for any website.|
+|[Data Scraper](https://chrome.google.com/webstore/detail/data-scraper-easy-web-scr/nndknepjnldbdbepjfgmncbggmopgden)|| Extracts data out of HTML web pages and imports it into Microsoft Excel spreadsheets.|
+|[Email extract](https://chrome.google.com/webstore/detail/email-extract/ejecpjcajdpbjbmlcojcohgenjngflac)|| Helps in finding email addresses on the pages you visit.|
+|[Hunter](https://chrome.google.com/webstore/detail/hunter-email-finder-exten/hgmhmanijnjhaffoampdlllchpolkdnj)|| Extension to find an email address on any website with one click.|
 |[MEGA](https://chrome.google.com/webstore/detail/mega/bigefpfhnfcobdlfbedofhhaibnlghod)|| Excellent file hosting service and a fairly secure messenger all rolled into one.|
-|[OSIRIS](https://chrome.google.com/webstore/detail/osiris-osint-reputation-i/jjdjccppehnjdennppcnlnaadcdlffdf)|| Extension for IoC reputation analysis.| 
-|[Sputnik](https://chrome.google.com/webstore/detail/sputnik/manapjdamopgbpimgojkccikaabhmocd)|| Extension to quickly and easily search for IP addresses, domains, file hashes and URLs using free resources.| 
-|[IP Address and Domain Information](https://chrome.google.com/webstore/detail/ip-address-and-domain-inf/lhgkegeccnckoiliokondpaaalbhafoa)|| The module displays detailed information about the current website.| 
-|[Shodan](https://chrome.google.com/webstore/detail/shodan/jjalcfnidlmpjhdfepjhjbhnhkbgleap)|| This plugin tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.| 
+|[OSIRIS](https://chrome.google.com/webstore/detail/osiris-osint-reputation-i/jjdjccppehnjdennppcnlnaadcdlffdf)|| Extension for IoC reputation analysis.|
+|[Sputnik](https://chrome.google.com/webstore/detail/sputnik/manapjdamopgbpimgojkccikaabhmocd)|| Extension to quickly and easily search for IP addresses, domains, file hashes and URLs using free resources.|
+|[IP Address and Domain Information](https://chrome.google.com/webstore/detail/ip-address-and-domain-inf/lhgkegeccnckoiliokondpaaalbhafoa)|| The module displays detailed information about the current website.|
+|[Shodan](https://chrome.google.com/webstore/detail/shodan/jjalcfnidlmpjhdfepjhjbhnhkbgleap)|| This plugin tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.|
 |[Pulsedive Threat Intelligence](https://chrome.google.com/webstore/detail/pulsedive-threat-intellig/gdbemlfgncdmmljmkkcemfedbbfgghcp)|| Free analyst-centric threat intelligence platform that offers comprehensive.|
-|[Mitaka](https://chrome.google.com/webstore/detail/mitaka/bfjbejmeoibbdpfdbmbacmefcbannnbg)|| Extension for searching IP, domain, URL, hash, etc. via the context menu.| 
-|[CrowdScrape](https://chrome.google.com/webstore/detail/crowdscrape/jjplaeklnlddpkbbdbnogmppffokemej)|| Plugin designed to allow you to be able to scrape indicators from various websites and in-browser documents such as PDF reports.| 
-|[ZoomEye Tools](https://chrome.google.com/webstore/detail/zoomeye-tools/bdoaeiibkccgkbjbmmmoemghacnkbklj)|| Plugin tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.| 
-|[FOFA Pro View](https://chrome.google.com/webstore/detail/fofa-pro-view/dobbfkjhgbkmmcooahlnllfopfmhcoln)|| Plugin tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.| 
+|[Mitaka](https://chrome.google.com/webstore/detail/mitaka/bfjbejmeoibbdpfdbmbacmefcbannnbg)|| Extension for searching IP, domain, URL, hash, etc. via the context menu.|
+|[CrowdScrape](https://chrome.google.com/webstore/detail/crowdscrape/jjplaeklnlddpkbbdbnogmppffokemej)|| Plugin designed to allow you to be able to scrape indicators from various websites and in-browser documents such as PDF reports.|
+|[ZoomEye Tools](https://chrome.google.com/webstore/detail/zoomeye-tools/bdoaeiibkccgkbjbmmmoemghacnkbklj)|| Plugin tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.|
+|[FOFA Pro View](https://chrome.google.com/webstore/detail/fofa-pro-view/dobbfkjhgbkmmcooahlnllfopfmhcoln)|| Plugin tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.|
 |[NoScript](https://chrome.google.com/webstore/detail/noscript/doojmbjmlfjjnbmnoijecmcbfeoakpjm/%7D)|| Allows you to run JavaScript, Flash, Java and other executable content only from trusted domains of your choice.|
-|[HTTPS Everywhere](https://chrome.google.com/webstore/detail/https-everywhere/gcbommkclmclpchllfjekcdonpmejbdp)|| Encrypts your communication with many major websites, making your web surfing more secure.| 
-|[Vytal](https://chrome.google.com/webstore/detail/vytal/ncbknoohfjmcfneopnfkapmkblaenokb)|| Extension that changes your location to match your VPN.| 
-|[Vulners Web Scanner](https://chrome.google.com/webstore/detail/vulners-web-scanner/dgdelbjijbkahooafjfnonijppnffhmd)|| Vulnerability scanner based on the vulners.com vulnerability database. | 
-|[User-Agent Switcher and Manager](https://chrome.google.com/webstore/detail/user-agent-switcher-and-m/bhchdcejhohfmigjafbampogmaanbfkg)|| Extension replaces the User-Agent on websites, which allows you to fake the digital fingerprint of the researcher’s device, pretending to be a smartphone or iPad.| 
-|[ClearURLs](https://chrome.google.com/webstore/detail/clearurls/lckanjgmijmafbedllaakclkaicjfmnk?hl=en)|| Application for stripping tracking tags from URLs.| 
+|[HTTPS Everywhere](https://chrome.google.com/webstore/detail/https-everywhere/gcbommkclmclpchllfjekcdonpmejbdp)|| Encrypts your communication with many major websites, making your web surfing more secure.|
+|[Vytal](https://chrome.google.com/webstore/detail/vytal/ncbknoohfjmcfneopnfkapmkblaenokb)|| Extension that changes your location to match your VPN.|
+|[Vulners Web Scanner](https://chrome.google.com/webstore/detail/vulners-web-scanner/dgdelbjijbkahooafjfnonijppnffhmd)|| Vulnerability scanner based on the vulners.com vulnerability database. |
+|[User-Agent Switcher and Manager](https://chrome.google.com/webstore/detail/user-agent-switcher-and-m/bhchdcejhohfmigjafbampogmaanbfkg)|| Extension replaces the User-Agent on websites, which allows you to fake the digital fingerprint of the researcher’s device, pretending to be a smartphone or iPad.|
+|[ClearURLs](https://chrome.google.com/webstore/detail/clearurls/lckanjgmijmafbedllaakclkaicjfmnk?hl=en)|| Application for stripping tracking tags from URLs.|
 |[uBlock Origin](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm)|| Best app for blocking ads and trackers on the internet today.|
-|[AdNauseam](https://adnauseam.io/)|| An ad blocker.| 
-|[Extensity](https://chrome.google.com/webstore/detail/extensity/jjmflmamggggndanpgfnpelongoepncg)|| Quickly enable/disable Google Chrome extensions.| 
-|[Extension Manager](https://chrome.google.com/webstore/detail/extension-manager/gjldcdngmdknpinoemndlidpcabkggco)|| Google Chrome extensions manager.| 
-|[BuiltWith Technology Profiler](https://chrome.google.com/webstore/detail/builtwith-technology-prof/dapjbgnjinbpoindlpdmhochffioedbn)|| Lets you find out what a website is built with by a simple click.| 
+|[AdNauseam](https://adnauseam.io/)|| An ad blocker.|
+|[Extensity](https://chrome.google.com/webstore/detail/extensity/jjmflmamggggndanpgfnpelongoepncg)|| Quickly enable/disable Google Chrome extensions.|
+|[Extension Manager](https://chrome.google.com/webstore/detail/extension-manager/gjldcdngmdknpinoemndlidpcabkggco)|| Google Chrome extensions manager.|
+|[BuiltWith Technology Profiler](https://chrome.google.com/webstore/detail/builtwith-technology-prof/dapjbgnjinbpoindlpdmhochffioedbn)|| Lets you find out what a website is built with by a simple click.|
 |[Email extract](https://chrome.google.com/webstore/detail/email-extract/ejecpjcajdpbjbmlcojcohgenjngflac)|| searches email addresses on pages you visit.|
-|[Ghostery – Privacy Ad Blocker](https://chrome.google.com/webstore/detail/ghostery-%E2%80%93-privacy-ad-blo/mlomiejdfkolichcflejclcbmpeaniij?hl=en)|| Block ads, stop trackers and speed up websites.| 
+|[Ghostery – Privacy Ad Blocker](https://chrome.google.com/webstore/detail/ghostery-%E2%80%93-privacy-ad-blo/mlomiejdfkolichcflejclcbmpeaniij?hl=en)|| Block ads, stop trackers and speed up websites.|
 |[Hunter - Email Finder Extension](https://chrome.google.com/webstore/detail/hunter-email-finder-exten/hgmhmanijnjhaffoampdlllchpolkdnj)|| Find email addresses from anywhere on the web, with just one click.|
-|[Instant Data Scraper](https://chrome.google.com/webstore/detail/instant-data-scraper/ofaokhiedipichpaobibbnahnkdoiiah)|| Instant Data Scraper extracts data from web pages and exports it as Excel or CSV files| 
-|[IP Address and Domain Information](https://chrome.google.com/webstore/detail/ip-address-and-domain-inf/lhgkegeccnckoiliokondpaaalbhafoa)||  See detailed information about every IP Address, Domain Name and Provider.| 
-|[Mitaka](https://chrome.google.com/webstore/detail/mitaka/bfjbejmeoibbdpfdbmbacmefcbannnbg?hl=en)|| extension for searching IP, domain, URL, hash, etc. via the context menu.| 
-|[Save to Pocket](https://chrome.google.com/webstore/detail/save-to-pocket/niloccemoadcdkdjlinkgdfekeahmflj)|| The easiest, fastest way to capture articles, videos, and more.| 
+|[Instant Data Scraper](https://chrome.google.com/webstore/detail/instant-data-scraper/ofaokhiedipichpaobibbnahnkdoiiah)|| Instant Data Scraper extracts data from web pages and exports it as Excel or CSV files|
+|[IP Address and Domain Information](https://chrome.google.com/webstore/detail/ip-address-and-domain-inf/lhgkegeccnckoiliokondpaaalbhafoa)||  See detailed information about every IP Address, Domain Name and Provider.|
+|[Mitaka](https://chrome.google.com/webstore/detail/mitaka/bfjbejmeoibbdpfdbmbacmefcbannnbg?hl=en)|| extension for searching IP, domain, URL, hash, etc. via the context menu.|
+|[Save to Pocket](https://chrome.google.com/webstore/detail/save-to-pocket/niloccemoadcdkdjlinkgdfekeahmflj)|| The easiest, fastest way to capture articles, videos, and more.|
 |[Simplescraper — a fast and free web scraper](https://chrome.google.com/webstore/detail/simplescraper-%E2%80%94-a-fast-an/lnddbhdmiciimpkbilgpklcglkdegdkg)|| Scrape website data and table data in seconds|
-|[Sputnik](https://chrome.google.com/webstore/detail/sputnik/manapjdamopgbpimgojkccikaabhmocd)|| quickly and easily search IPs, Domains, File Hashes, and URLs| 
-|[Unpaywall](https://chrome.google.com/webstore/detail/unpaywall/iplffkdpngmdjhlpjmppncnlhomiipha)|| for accessing articles that are available elsewhere for free.| 
-|[Wappalyzer](https://addons.mozilla.org/en-US/firefox/addon/wappalyzer/)|| Helpful in identifying technologies on websites.| 
-|[Scan WP - WordPress Theme and Plugin Detector](https://chrome.google.com/webstore/detail/scan-wp-wordpress-theme-a/jgepgcdhakjacecafilmhdnifekocmcl)|| Detects what theme and plugins are used in the Wordpress website| 
+|[Sputnik](https://chrome.google.com/webstore/detail/sputnik/manapjdamopgbpimgojkccikaabhmocd)|| quickly and easily search IPs, Domains, File Hashes, and URLs|
+|[Unpaywall](https://chrome.google.com/webstore/detail/unpaywall/iplffkdpngmdjhlpjmppncnlhomiipha)|| for accessing articles that are available elsewhere for free.|
+|[Wappalyzer](https://addons.mozilla.org/en-US/firefox/addon/wappalyzer/)|| Helpful in identifying technologies on websites.|
+|[Scan WP - WordPress Theme and Plugin Detector](https://chrome.google.com/webstore/detail/scan-wp-wordpress-theme-a/jgepgcdhakjacecafilmhdnifekocmcl)|| Detects what theme and plugins are used in the Wordpress website|
 |[Fake Profile Detector (Deepfake, GAN)](https://chrome.google.com/webstore/detail/fake-profile-detector-dee/jbpcgcnnhmjmajjkgdaogpgefbnokpcc)|| Detects if that image contains a GAN generated or real person!|
-|[Screenshot YouTube](https://chrome.google.com/webstore/detail/screenshot-youtube/gjoijpfmdhbjkkgnmahganhoinjjpohk)|| Take a screenshot of any YouTube video with one click.| 
-|[Canvas Fingerprint Defender](https://chrome.google.com/webstore/detail/canvas-fingerprint-defend/lanfdkkpgfjfdikkncbnojekcppdebfp)|| Lets you easily hide your real canvas fingerprint by reporting a random fake value.| 
-|[Chaff](https://chrome.google.com/webstore/detail/chaff/jgjhamliocfhehbocekgcddfjpgdjnje)|| Generate random web browsing traffic to obfuscate actual browsing behavior to avoid profiling through 3rd party observation.| 
-|[ClearURLs](https://chrome.google.com/webstore/detail/clearurls/lckanjgmijmafbedllaakclkaicjfmnk)|| Automatically remove tracking elements from URLs to help protect your privacy when browse through the Internet.| 
+|[Screenshot YouTube](https://chrome.google.com/webstore/detail/screenshot-youtube/gjoijpfmdhbjkkgnmahganhoinjjpohk)|| Take a screenshot of any YouTube video with one click.|
+|[Canvas Fingerprint Defender](https://chrome.google.com/webstore/detail/canvas-fingerprint-defend/lanfdkkpgfjfdikkncbnojekcppdebfp)|| Lets you easily hide your real canvas fingerprint by reporting a random fake value.|
+|[Chaff](https://chrome.google.com/webstore/detail/chaff/jgjhamliocfhehbocekgcddfjpgdjnje)|| Generate random web browsing traffic to obfuscate actual browsing behavior to avoid profiling through 3rd party observation.|
+|[ClearURLs](https://chrome.google.com/webstore/detail/clearurls/lckanjgmijmafbedllaakclkaicjfmnk)|| Automatically remove tracking elements from URLs to help protect your privacy when browse through the Internet.|
 |[Location Guard](https://chrome.google.com/webstore/detail/location-guard/cfohepagpmnodfdmjliccbbigdkfcgia)|| Hide your geographic location from websites.|
-|[Decentraleyes](https://chrome.google.com/webstore/detail/decentraleyes/ldpochfccmkkmhdbclfhpagapcfdljkj)|| Protects you against tracking through "free", centralized, content delivery.| 
+|[Decentraleyes](https://chrome.google.com/webstore/detail/decentraleyes/ldpochfccmkkmhdbclfhpagapcfdljkj)|| Protects you against tracking through "free", centralized, content delivery.|
 |[Netcraft Extension](https://addons.mozilla.org/en-US/firefox/addon/netcraft-toolbar/)|| Provides comprehensive site information and protection from phishing and malicious JavaScript when browsing the web|
-|[Image Downloader - Save photos and pictures](https://chrome.google.com/webstore/detail/image-downloader-save-pho/lbohagbplppjcpllnhdichjldhfgkicb)|| Find, choose and download images you need from any web pages or select all to bulk image download.| 
+|[Image Downloader - Save photos and pictures](https://chrome.google.com/webstore/detail/image-downloader-save-pho/lbohagbplppjcpllnhdichjldhfgkicb)|| Find, choose and download images you need from any web pages or select all to bulk image download.|
 |[L.O.C](https://chrome.google.com/webstore/detail/loc/eojdckfcadamkapabechhbnkleligand)|| collection of tools to help Facebook users with a downloading content and analysis.|
-|[Return YouTube Comment Username](https://chrome.google.com/webstore/detail/return-youtube-comment-us/kamibelompadnaekbellinmgbphoidmj)|| Replaces the "handle" in the YouTube comments section to user name| 
-|[TikNote: Video Downloader and Saver](https://chrome.google.com/webstore/detail/tiknote-video-downloader/jilgamolkonoalagcpgjjijaclacillb)|| Download TikTok™ videos without watermark.| 
+|[Return YouTube Comment Username](https://chrome.google.com/webstore/detail/return-youtube-comment-us/kamibelompadnaekbellinmgbphoidmj)|| Replaces the "handle" in the YouTube comments section to user name|
+|[TikNote: Video Downloader and Saver](https://chrome.google.com/webstore/detail/tiknote-video-downloader/jilgamolkonoalagcpgjjijaclacillb)|| Download TikTok™ videos without watermark.|
 |[TT Downloader](https://chrome.google.com/webstore/detail/tt-downloader/blbckhiepgpniilpmlionnkjoeehhgao?hl=en-GB)|| Download Tik tok Videos and Mass Downloads|
-|[Video Downloader Plus](https://chrome.google.com/webstore/detail/video-downloader-plus/hkdmdpdhfaamhgaojpelccmeehpfljgf)|| The fastest and easiest way to download any video from any website.| 
-|[Uniform Timezone Extension](https://chrome.google.com/webstore/detail/uniform-timezone-extensio/fhpdgikedeljapdckiegnjiendkhphlg)|| Brings standardization to social media posts' dates and times.| 
-|[Linkclump](https://chrome.google.com/webstore/detail/linkclump/lfpjkncokllnfokkgpkobnkbkmelfefj)|| Lets you open, copy or bookmark multiple links at the same time.| 
-|[OpenLink Structured Data Sniffer](https://chrome.google.com/webstore/detail/openlink-structured-data/egdaiaihbdoiibopledjahjaihbmjhdj)|| Reveals structured metadata (Microdata, RDFa, JSON-LD, Turtle, etc.) embedded within HTML documents.| 
+|[Video Downloader Plus](https://chrome.google.com/webstore/detail/video-downloader-plus/hkdmdpdhfaamhgaojpelccmeehpfljgf)|| The fastest and easiest way to download any video from any website.|
+|[Uniform Timezone Extension](https://chrome.google.com/webstore/detail/uniform-timezone-extensio/fhpdgikedeljapdckiegnjiendkhphlg)|| Brings standardization to social media posts' dates and times.|
+|[Linkclump](https://chrome.google.com/webstore/detail/linkclump/lfpjkncokllnfokkgpkobnkbkmelfefj)|| Lets you open, copy or bookmark multiple links at the same time.|
+|[OpenLink Structured Data Sniffer](https://chrome.google.com/webstore/detail/openlink-structured-data/egdaiaihbdoiibopledjahjaihbmjhdj)|| Reveals structured metadata (Microdata, RDFa, JSON-LD, Turtle, etc.) embedded within HTML documents.|
 |[Link Gopher](https://chrome.google.com/webstore/detail/link-gopher/bpjdkodgnbfalgghnbeggfbfjpcfamkf)|| Extracts all links from web page, sorts them, removes duplicates, and displays them in a new tab for copy and paste into other systems.|
-|[Page Monitor](https://chrome.google.com/webstore/detail/page-monitor/ogeebjpdeabhncjpfhgdibjajcajepgg)|| Stays in the background and monitors web pages for changes.| 
-|[Pulsedive Threat Intelligence](https://chrome.google.com/webstore/detail/pulsedive-threat-intellig/gdbemlfgncdmmljmkkcemfedbbfgghcp)|| Highlight IPs, domains, and URLs on any website to enrich them using Pulsedive's free threat intelligence data set.| 
+|[Page Monitor](https://chrome.google.com/webstore/detail/page-monitor/ogeebjpdeabhncjpfhgdibjajcajepgg)|| Stays in the background and monitors web pages for changes.|
+|[Pulsedive Threat Intelligence](https://chrome.google.com/webstore/detail/pulsedive-threat-intellig/gdbemlfgncdmmljmkkcemfedbbfgghcp)|| Highlight IPs, domains, and URLs on any website to enrich them using Pulsedive's free threat intelligence data set.|
 |[Save Page WE](https://chrome.google.com/webstore/detail/save-page-we/dhhpefjklgkmgeafimnjhojgjamoafof)|| Save a complete web page (as curently displayed) as a single HTML file that can be opened in any browser.|
 |[ThreatPinch Lookup](https://chrome.google.com/webstore/detail/threatpinch-lookup/ljdgplocfnmnofbhpkjclbefmjoikgke)|| Add threat intelligence hover tool tips. IPv4, MD5, SHA2, CVE, FQDN or add your own ThreatIntel IOC. Use any REST API.|
-|[Web Archives](https://chrome.google.com/webstore/detail/web-archives/hkligngkgcpcolhcnkgccglchdafcnao)|| View archived and cached versions of web pages on 10+ search engines, such as the Wayback Machine, Archive.is and Google.| 
-|[Nimbus Screenshot & Screen Video Recorder](https://chrome.google.com/webstore/detail/nimbus-screenshot-screen/bpconcjcammlapcogcnnelfmaeghhagj)|| Screen Capture FULL Web page or any part. Edit screenshots. Record screencasts - record video from your screen.| 
+|[Web Archives](https://chrome.google.com/webstore/detail/web-archives/hkligngkgcpcolhcnkgccglchdafcnao)|| View archived and cached versions of web pages on 10+ search engines, such as the Wayback Machine, Archive.is and Google.|
+|[Nimbus Screenshot & Screen Video Recorder](https://chrome.google.com/webstore/detail/nimbus-screenshot-screen/bpconcjcammlapcogcnnelfmaeghhagj)|| Screen Capture FULL Web page or any part. Edit screenshots. Record screencasts - record video from your screen.|
 |[FOCA Files Finder](https://chrome.google.com/webstore/detail/foca-files-finder/mhobefinhafbleanihidiifaedcceoij)|| Scans for available files for a website and provide with the download link for analyzing locally.
 
 **Firefox Extensions**
 
-| Name |      | Description                | 
-| :-------- | :------- | :------------------------- | 
-|[Multi-Account Containers](https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers/)|| Allows you to open tabs which are completely isolated from each other and don't share the same cookies, session data, or other information.| 
+| Name |      | Description                |
+| :-------- | :------- | :------------------------- |
+|[Multi-Account Containers](https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers/)|| Allows you to open tabs which are completely isolated from each other and don't share the same cookies, session data, or other information.|
 |[FireShot: Full Web Page Screenshots](https://addons.mozilla.org/en-US/firefox/addon/fireshot/)|| Allows you to capture and save the visible part, a selected area of the page or the full web page, including parts that are not visible.|
-|[uBlock Origin](https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/)|| Helps in enhancing security of the browser by blocking ads, trackers, and malware sites.| 
-|[DownThemAll!](https://addons.mozilla.org/en-US/firefox/addon/downthemall/)|| Allows you to download all media, like videos and images, from a website and save them on your computer.| 
-|[ScrapBee](https://addons.mozilla.org/en-US/firefox/addon/scrapbee/)|| Allows you to save entire web pages for offline access and allowing them to organize for a good overview.| 
-|[Search by Image](https://addons.mozilla.org/en-US/firefox/addon/search_by_image/)|| Allows you to conduct a reverse image search on multiple databases (like Google, Bing, Yandex, TinEye, SauceNAO, IQDB) at the same time by right-clicking on the image on the website.| 
+|[uBlock Origin](https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/)|| Helps in enhancing security of the browser by blocking ads, trackers, and malware sites.|
+|[DownThemAll!](https://addons.mozilla.org/en-US/firefox/addon/downthemall/)|| Allows you to download all media, like videos and images, from a website and save them on your computer.|
+|[ScrapBee](https://addons.mozilla.org/en-US/firefox/addon/scrapbee/)|| Allows you to save entire web pages for offline access and allowing them to organize for a good overview.|
+|[Search by Image](https://addons.mozilla.org/en-US/firefox/addon/search_by_image/)|| Allows you to conduct a reverse image search on multiple databases (like Google, Bing, Yandex, TinEye, SauceNAO, IQDB) at the same time by right-clicking on the image on the website.|
 |[User-Agent Switcher and Manager](https://addons.mozilla.org/en-US/firefox/addon/user-agent-string-switcher/)|| Allows you to alter your user-agent string to indicate you’re on a different device.|
-|[NoScript Security Suite](https://addons.mozilla.org/en-US/firefox/addon/noscript/)|| Allow potentially malicious web content to run only from sites you trust.| 
-|[Privacy Badger](https://addons.mozilla.org/en-US/firefox/addon/privacy-badger17/)|| Allows to block invisible trackers automatically.| 
-|[Cookie AutoDelete](https://addons.mozilla.org/en-US/firefox/addon/cookie-autodelete/)|| Allows you to control your cookies.| 
-|[Shodan](https://addons.mozilla.org/en-US/firefox/addon/shodan-addon/)|| Tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.| 
+|[NoScript Security Suite](https://addons.mozilla.org/en-US/firefox/addon/noscript/)|| Allow potentially malicious web content to run only from sites you trust.|
+|[Privacy Badger](https://addons.mozilla.org/en-US/firefox/addon/privacy-badger17/)|| Allows to block invisible trackers automatically.|
+|[Cookie AutoDelete](https://addons.mozilla.org/en-US/firefox/addon/cookie-autodelete/)|| Allows you to control your cookies.|
+|[Shodan](https://addons.mozilla.org/en-US/firefox/addon/shodan-addon/)|| Tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.|
 |[Netcraft Extension](https://addons.mozilla.org/en-US/firefox/addon/netcraft-toolbar/)|| Provides comprehensive site information and protection from phishing and malicious JavaScript when browsing the web|
-|[Wappalyzer](https://addons.mozilla.org/en-US/firefox/addon/wappalyzer/)|| Helpful in identifying technologies on websites.| 
+|[Wappalyzer](https://addons.mozilla.org/en-US/firefox/addon/wappalyzer/)|| Helpful in identifying technologies on websites.|
+|[PastPage](https://addons.mozilla.org/en-US/firefox/addon/pastpage-query-10-web-archives/)|| Helps recover broken or changed pages by querying the Wayback Machine and other web archives in parallel.|
 |[Wayback Machine](https://addons.mozilla.org/en-US/firefox/addon/wayback-machine_new/)|| Allows to go back in time to see how a website has changed through the history of the Web.|
 
 ## Credits -

--- a/README.md
+++ b/README.md
@@ -65,116 +65,114 @@ https://www.youtube.com/watch?v=ekXS3y_s8k8
 ## Browser Extensions for OSINT
 
 **Chrome Extension** -
-| Name |      | Description                |
-| :-------- | :------- | :------------------------- |
+| Name |      | Description                | 
+| :-------- | :------- | :------------------------- | 
 |[Ubikron](https://www.ubikron.com/)||Chrome extension that speaks to a server (in the cloud or in your server room) and keeps track of sites you’ve browsed to. It saves screenshots of the sites as well as all the body text. |
-|[Vortimo OSINT-tool](https://chrome.google.com/webstore/detail/vortimo-osint-tool/mnakbpdnkedaegeiaoakkjafhoidklnf)||Helps in getting more information about name, phone number, email, and many more. |
-|[Hunchly 2.0](https://chrome.google.com/webstore/detail/hunchly-20/amfnegileeghgikpggcebehdepknalbf)|| Helps in capture and organize online data for your investigations.|
-|[Selection Search](https://chrome.google.com/webstore/detail/selection-search/gipnlpdeieaidmmeaichnddnmjmcakoe)|| Helps you in searching for the selected text in multiple search engines|
-|[Email Tracker](https://chrome.google.com/webstore/detail/email-tracker/bnompdfnhdbgdaoanapncknhmckenfog)||Helps you in finding out if your email has been read|
-|[Geotrack Email Tracking with Geolocation](https://chrome.google.com/webstore/detail/geotrack-email-tracking-w/ciajnfanflofkddjdanppgnlpkkdclln)|| Helps you in Email tracking with geolocation right in Gmail, with real-time statistics|
-|[Gotanda](https://chrome.google.com/webstore/detail/gotanda/jbmdcdfnnpenkgliplbglfpninigbiml)|| Helpful for searching OSINT information from some IOC in web page.(IP,Domain,URL,SNS...etc)|
-|[Map Switcher](https://chrome.google.com/webstore/detail/map-switcher/fanpjcbgdinjeknjikpfnldfpnnpkelb?hl=en)|| Helpful in switching between different map services with a single click|
-|[Magnifying Glass](https://chrome.google.com/webstore/detail/magnifying-glass/elhdjgjjmodgmhkokebhegekjooiaofm)|| Helpful in viewing a zoomed image within its radius, without disturbing the rest of the page.|
-|[EXIF Viewer Pro](https://chrome.google.com/webstore/detail/exif-viewer-pro/mmbhfeiddhndihdjeganjggkmjapkffm)|| Helpful in quickly accessing exif data of any image you view.|
-|[Fake news debunker by InVID & WeVerify](https://chrome.google.com/webstore/detail/fake-news-debunker-by-inv/mhccpoafgdgbhnjfhkcmgknndkeenfhe?hl=en)|| Helpful for journalists, fact-checkers and human right defenders in fact-checking and debunking tasks on social networks.|
-|[TinEye Reverse Image Search](https://chrome.google.com/webstore/detail/tineye-reverse-image-sear/haebnnbpedcbhciplfhjjkbafijpncjl)|| Helpful in reverse image search and other features offered by Tineye|
-|[Search by Image](https://chrome.google.com/webstore/detail/search-by-image/cnojnbdhbhnkbcieeekonklommdnndci)|| Helpful in reverse image search with support for various search engines, such as Google, Bing, Yandex, Baidu and TinEye.|
-|[PhotOSINT](https://chrome.google.com/webstore/detail/photosint/gonhdjmkgfkokhkflfhkbiagbmoolhcd)|| Helpful in scanning images for exif metadata while browsing|
-|[Resemble AI Deepfake Detector](https://chromewebstore.google.com/detail/resemble-ai-deepfake-dete/ligejojghpehckjpfldljdcckgcbngle)|| Helpful for scanning web images, videos, and audio for AI-generated or manipulated media with verdicts and confidence scores.|
-|[Distill](https://chrome.google.com/webstore/detail/distill-web-monitor/inlikjemeeknofckkjolnjbpehgadgge?hl=en-US)|| Extension allows you to passively monitor changes on social pages.|
-|[Visualping](https://chrome.google.com/webstore/detail/visualping/pemhgklkefakciniebenbfclihhmmfcd)|| A simple service for monitoring websites for changes.|
-|[Fetcher](https://chrome.google.com/webstore/detail/fetcher/hcjoaaeflhldlbmadokknllgaagbonla/)|| Extension fetches from your favourite websites, and combines them into one|
-|[FireShot](https://chrome.google.com/webstore/detail/take-webpage-screenshots/mcbpblocgmgfnpjjppndjkmgjaogfceg?hl=en-US)|| Allows you to quickly take a screenshot of a web page in full screen mode.|
-|[Nimbus Screenshot & Screen Video Recorder](https://chrome.google.com/webstore/detail/nimbus-screenshot-screen/bpconcjcammlapcogcnnelfmaeghhagj)|| Helpful for taking screenshots and video recording web pages.|
-|[Go Back in Time](https://chrome.google.com/webstore/detail/go-back-in-time/hgdahcpipmgehmaaankiglanlgljlakj)|| Allows you to view an archived version of a web page.|
-|[PastPage](https://chromewebstore.google.com/detail/pastpage-query-10+-web-ar/icpegbecignmplpkjjcegmjmfadpcpoo)|| Helps recover broken or changed pages by querying the Wayback Machine and other web archives in parallel.|
-|[The Wayback Machine](https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak)|| Extension of the Internet Archive|
-|[Web Cache Viewer](https://chrome.google.com/webstore/detail/web-cache-viewer/pbkloffickinnlnmefmjmjbacohecpbd)|| lets you right-click on any link or page to view the Wayback Machine or Google Cache versions of that page.|
-|[Blockchain.info](https://chrome.google.com/webstore/detail/blockchaininfo-address-se/aipmpbhchlkopmpoaipbelfpniojcnkb)|| Helps to find info on bitcoin address.|
-|[Blockchair](https://chrome.google.com/webstore/detail/blockchair/fhhkkooikehnkaodebbfnkinedlllcfk)|| Block explorer and anonymous crypto portfolio tracker for Bitcoin, Ethereum, and others in your browser.|
+|[Vortimo OSINT-tool](https://chrome.google.com/webstore/detail/vortimo-osint-tool/mnakbpdnkedaegeiaoakkjafhoidklnf)||Helps in getting more information about name, phone number, email, and many more. | 
+|[Hunchly 2.0](https://chrome.google.com/webstore/detail/hunchly-20/amfnegileeghgikpggcebehdepknalbf)|| Helps in capture and organize online data for your investigations.| 
+|[Selection Search](https://chrome.google.com/webstore/detail/selection-search/gipnlpdeieaidmmeaichnddnmjmcakoe)|| Helps you in searching for the selected text in multiple search engines| 
+|[Email Tracker](https://chrome.google.com/webstore/detail/email-tracker/bnompdfnhdbgdaoanapncknhmckenfog)||Helps you in finding out if your email has been read| 
+|[Geotrack Email Tracking with Geolocation](https://chrome.google.com/webstore/detail/geotrack-email-tracking-w/ciajnfanflofkddjdanppgnlpkkdclln)|| Helps you in Email tracking with geolocation right in Gmail, with real-time statistics| 
+|[Gotanda](https://chrome.google.com/webstore/detail/gotanda/jbmdcdfnnpenkgliplbglfpninigbiml)|| Helpful for searching OSINT information from some IOC in web page.(IP,Domain,URL,SNS...etc)| 
+|[Map Switcher](https://chrome.google.com/webstore/detail/map-switcher/fanpjcbgdinjeknjikpfnldfpnnpkelb?hl=en)|| Helpful in switching between different map services with a single click| 
+|[Magnifying Glass](https://chrome.google.com/webstore/detail/magnifying-glass/elhdjgjjmodgmhkokebhegekjooiaofm)|| Helpful in viewing a zoomed image within its radius, without disturbing the rest of the page.| 
+|[EXIF Viewer Pro](https://chrome.google.com/webstore/detail/exif-viewer-pro/mmbhfeiddhndihdjeganjggkmjapkffm)|| Helpful in quickly accessing exif data of any image you view.| 
+|[Fake news debunker by InVID & WeVerify](https://chrome.google.com/webstore/detail/fake-news-debunker-by-inv/mhccpoafgdgbhnjfhkcmgknndkeenfhe?hl=en)|| Helpful for journalists, fact-checkers and human right defenders in fact-checking and debunking tasks on social networks.| 
+|[TinEye Reverse Image Search](https://chrome.google.com/webstore/detail/tineye-reverse-image-sear/haebnnbpedcbhciplfhjjkbafijpncjl)|| Helpful in reverse image search and other features offered by Tineye| 
+|[Search by Image](https://chrome.google.com/webstore/detail/search-by-image/cnojnbdhbhnkbcieeekonklommdnndci)|| Helpful in reverse image search with support for various search engines, such as Google, Bing, Yandex, Baidu and TinEye.| 
+|[PhotOSINT](https://chrome.google.com/webstore/detail/photosint/gonhdjmkgfkokhkflfhkbiagbmoolhcd)|| Helpful in scanning images for exif metadata while browsing| 
+|[Resemble AI Deepfake Detector](https://chromewebstore.google.com/detail/resemble-ai-deepfake-dete/ligejojghpehckjpfldljdcckgcbngle)|| Helpful for scanning web images, videos, and audio for AI-generated or manipulated media with verdicts and confidence scores.| 
+|[Distill](https://chrome.google.com/webstore/detail/distill-web-monitor/inlikjemeeknofckkjolnjbpehgadgge?hl=en-US)|| Extension allows you to passively monitor changes on social pages.| 
+|[Visualping](https://chrome.google.com/webstore/detail/visualping/pemhgklkefakciniebenbfclihhmmfcd)|| A simple service for monitoring websites for changes.| 
+|[Fetcher](https://chrome.google.com/webstore/detail/fetcher/hcjoaaeflhldlbmadokknllgaagbonla/)|| Extension fetches from your favourite websites, and combines them into one| 
+|[FireShot](https://chrome.google.com/webstore/detail/take-webpage-screenshots/mcbpblocgmgfnpjjppndjkmgjaogfceg?hl=en-US)|| Allows you to quickly take a screenshot of a web page in full screen mode.| 
+|[Nimbus Screenshot & Screen Video Recorder](https://chrome.google.com/webstore/detail/nimbus-screenshot-screen/bpconcjcammlapcogcnnelfmaeghhagj)|| Helpful for taking screenshots and video recording web pages.| 
+|[Go Back in Time](https://chrome.google.com/webstore/detail/go-back-in-time/hgdahcpipmgehmaaankiglanlgljlakj)|| Allows you to view an archived version of a web page.| 
+|[The Wayback Machine](https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak)|| Extension of the Internet Archive| 
+|[Web Cache Viewer](https://chrome.google.com/webstore/detail/web-cache-viewer/pbkloffickinnlnmefmjmjbacohecpbd)|| lets you right-click on any link or page to view the Wayback Machine or Google Cache versions of that page.| 
+|[Blockchain.info](https://chrome.google.com/webstore/detail/blockchaininfo-address-se/aipmpbhchlkopmpoaipbelfpniojcnkb)|| Helps to find info on bitcoin address.| 
+|[Blockchair](https://chrome.google.com/webstore/detail/blockchair/fhhkkooikehnkaodebbfnkinedlllcfk)|| Block explorer and anonymous crypto portfolio tracker for Bitcoin, Ethereum, and others in your browser.| 
 |[Breadcrumbs Blockchain Investigate](https://chrome.google.com/webstore/detail/breadcrumbs-blockchain-in/dlnalaneihafdkdcekejdekiclgdghka)|| Investigation tool to get more details on any Ethereum address’s activity.|
-|[Instant Data Scraper](https://chrome.google.com/webstore/detail/instant-data-scraper/ofaokhiedipichpaobibbnahnkdoiiah)|| An automatic data scraping tool for any website.|
-|[Data Scraper](https://chrome.google.com/webstore/detail/data-scraper-easy-web-scr/nndknepjnldbdbepjfgmncbggmopgden)|| Extracts data out of HTML web pages and imports it into Microsoft Excel spreadsheets.|
-|[Email extract](https://chrome.google.com/webstore/detail/email-extract/ejecpjcajdpbjbmlcojcohgenjngflac)|| Helps in finding email addresses on the pages you visit.|
-|[Hunter](https://chrome.google.com/webstore/detail/hunter-email-finder-exten/hgmhmanijnjhaffoampdlllchpolkdnj)|| Extension to find an email address on any website with one click.|
+|[Instant Data Scraper](https://chrome.google.com/webstore/detail/instant-data-scraper/ofaokhiedipichpaobibbnahnkdoiiah)|| An automatic data scraping tool for any website.| 
+|[Data Scraper](https://chrome.google.com/webstore/detail/data-scraper-easy-web-scr/nndknepjnldbdbepjfgmncbggmopgden)|| Extracts data out of HTML web pages and imports it into Microsoft Excel spreadsheets.| 
+|[Email extract](https://chrome.google.com/webstore/detail/email-extract/ejecpjcajdpbjbmlcojcohgenjngflac)|| Helps in finding email addresses on the pages you visit.| 
+|[Hunter](https://chrome.google.com/webstore/detail/hunter-email-finder-exten/hgmhmanijnjhaffoampdlllchpolkdnj)|| Extension to find an email address on any website with one click.| 
 |[MEGA](https://chrome.google.com/webstore/detail/mega/bigefpfhnfcobdlfbedofhhaibnlghod)|| Excellent file hosting service and a fairly secure messenger all rolled into one.|
-|[OSIRIS](https://chrome.google.com/webstore/detail/osiris-osint-reputation-i/jjdjccppehnjdennppcnlnaadcdlffdf)|| Extension for IoC reputation analysis.|
-|[Sputnik](https://chrome.google.com/webstore/detail/sputnik/manapjdamopgbpimgojkccikaabhmocd)|| Extension to quickly and easily search for IP addresses, domains, file hashes and URLs using free resources.|
-|[IP Address and Domain Information](https://chrome.google.com/webstore/detail/ip-address-and-domain-inf/lhgkegeccnckoiliokondpaaalbhafoa)|| The module displays detailed information about the current website.|
-|[Shodan](https://chrome.google.com/webstore/detail/shodan/jjalcfnidlmpjhdfepjhjbhnhkbgleap)|| This plugin tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.|
+|[OSIRIS](https://chrome.google.com/webstore/detail/osiris-osint-reputation-i/jjdjccppehnjdennppcnlnaadcdlffdf)|| Extension for IoC reputation analysis.| 
+|[Sputnik](https://chrome.google.com/webstore/detail/sputnik/manapjdamopgbpimgojkccikaabhmocd)|| Extension to quickly and easily search for IP addresses, domains, file hashes and URLs using free resources.| 
+|[IP Address and Domain Information](https://chrome.google.com/webstore/detail/ip-address-and-domain-inf/lhgkegeccnckoiliokondpaaalbhafoa)|| The module displays detailed information about the current website.| 
+|[Shodan](https://chrome.google.com/webstore/detail/shodan/jjalcfnidlmpjhdfepjhjbhnhkbgleap)|| This plugin tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.| 
 |[Pulsedive Threat Intelligence](https://chrome.google.com/webstore/detail/pulsedive-threat-intellig/gdbemlfgncdmmljmkkcemfedbbfgghcp)|| Free analyst-centric threat intelligence platform that offers comprehensive.|
-|[Mitaka](https://chrome.google.com/webstore/detail/mitaka/bfjbejmeoibbdpfdbmbacmefcbannnbg)|| Extension for searching IP, domain, URL, hash, etc. via the context menu.|
-|[CrowdScrape](https://chrome.google.com/webstore/detail/crowdscrape/jjplaeklnlddpkbbdbnogmppffokemej)|| Plugin designed to allow you to be able to scrape indicators from various websites and in-browser documents such as PDF reports.|
-|[ZoomEye Tools](https://chrome.google.com/webstore/detail/zoomeye-tools/bdoaeiibkccgkbjbmmmoemghacnkbklj)|| Plugin tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.|
-|[FOFA Pro View](https://chrome.google.com/webstore/detail/fofa-pro-view/dobbfkjhgbkmmcooahlnllfopfmhcoln)|| Plugin tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.|
+|[Mitaka](https://chrome.google.com/webstore/detail/mitaka/bfjbejmeoibbdpfdbmbacmefcbannnbg)|| Extension for searching IP, domain, URL, hash, etc. via the context menu.| 
+|[CrowdScrape](https://chrome.google.com/webstore/detail/crowdscrape/jjplaeklnlddpkbbdbnogmppffokemej)|| Plugin designed to allow you to be able to scrape indicators from various websites and in-browser documents such as PDF reports.| 
+|[ZoomEye Tools](https://chrome.google.com/webstore/detail/zoomeye-tools/bdoaeiibkccgkbjbmmmoemghacnkbklj)|| Plugin tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.| 
+|[FOFA Pro View](https://chrome.google.com/webstore/detail/fofa-pro-view/dobbfkjhgbkmmcooahlnllfopfmhcoln)|| Plugin tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.| 
 |[NoScript](https://chrome.google.com/webstore/detail/noscript/doojmbjmlfjjnbmnoijecmcbfeoakpjm/%7D)|| Allows you to run JavaScript, Flash, Java and other executable content only from trusted domains of your choice.|
-|[HTTPS Everywhere](https://chrome.google.com/webstore/detail/https-everywhere/gcbommkclmclpchllfjekcdonpmejbdp)|| Encrypts your communication with many major websites, making your web surfing more secure.|
-|[Vytal](https://chrome.google.com/webstore/detail/vytal/ncbknoohfjmcfneopnfkapmkblaenokb)|| Extension that changes your location to match your VPN.|
-|[Vulners Web Scanner](https://chrome.google.com/webstore/detail/vulners-web-scanner/dgdelbjijbkahooafjfnonijppnffhmd)|| Vulnerability scanner based on the vulners.com vulnerability database. |
-|[User-Agent Switcher and Manager](https://chrome.google.com/webstore/detail/user-agent-switcher-and-m/bhchdcejhohfmigjafbampogmaanbfkg)|| Extension replaces the User-Agent on websites, which allows you to fake the digital fingerprint of the researcher’s device, pretending to be a smartphone or iPad.|
-|[ClearURLs](https://chrome.google.com/webstore/detail/clearurls/lckanjgmijmafbedllaakclkaicjfmnk?hl=en)|| Application for stripping tracking tags from URLs.|
+|[HTTPS Everywhere](https://chrome.google.com/webstore/detail/https-everywhere/gcbommkclmclpchllfjekcdonpmejbdp)|| Encrypts your communication with many major websites, making your web surfing more secure.| 
+|[Vytal](https://chrome.google.com/webstore/detail/vytal/ncbknoohfjmcfneopnfkapmkblaenokb)|| Extension that changes your location to match your VPN.| 
+|[Vulners Web Scanner](https://chrome.google.com/webstore/detail/vulners-web-scanner/dgdelbjijbkahooafjfnonijppnffhmd)|| Vulnerability scanner based on the vulners.com vulnerability database. | 
+|[User-Agent Switcher and Manager](https://chrome.google.com/webstore/detail/user-agent-switcher-and-m/bhchdcejhohfmigjafbampogmaanbfkg)|| Extension replaces the User-Agent on websites, which allows you to fake the digital fingerprint of the researcher’s device, pretending to be a smartphone or iPad.| 
+|[ClearURLs](https://chrome.google.com/webstore/detail/clearurls/lckanjgmijmafbedllaakclkaicjfmnk?hl=en)|| Application for stripping tracking tags from URLs.| 
 |[uBlock Origin](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm)|| Best app for blocking ads and trackers on the internet today.|
-|[AdNauseam](https://adnauseam.io/)|| An ad blocker.|
-|[Extensity](https://chrome.google.com/webstore/detail/extensity/jjmflmamggggndanpgfnpelongoepncg)|| Quickly enable/disable Google Chrome extensions.|
-|[Extension Manager](https://chrome.google.com/webstore/detail/extension-manager/gjldcdngmdknpinoemndlidpcabkggco)|| Google Chrome extensions manager.|
-|[BuiltWith Technology Profiler](https://chrome.google.com/webstore/detail/builtwith-technology-prof/dapjbgnjinbpoindlpdmhochffioedbn)|| Lets you find out what a website is built with by a simple click.|
+|[AdNauseam](https://adnauseam.io/)|| An ad blocker.| 
+|[Extensity](https://chrome.google.com/webstore/detail/extensity/jjmflmamggggndanpgfnpelongoepncg)|| Quickly enable/disable Google Chrome extensions.| 
+|[Extension Manager](https://chrome.google.com/webstore/detail/extension-manager/gjldcdngmdknpinoemndlidpcabkggco)|| Google Chrome extensions manager.| 
+|[BuiltWith Technology Profiler](https://chrome.google.com/webstore/detail/builtwith-technology-prof/dapjbgnjinbpoindlpdmhochffioedbn)|| Lets you find out what a website is built with by a simple click.| 
 |[Email extract](https://chrome.google.com/webstore/detail/email-extract/ejecpjcajdpbjbmlcojcohgenjngflac)|| searches email addresses on pages you visit.|
-|[Ghostery – Privacy Ad Blocker](https://chrome.google.com/webstore/detail/ghostery-%E2%80%93-privacy-ad-blo/mlomiejdfkolichcflejclcbmpeaniij?hl=en)|| Block ads, stop trackers and speed up websites.|
+|[Ghostery – Privacy Ad Blocker](https://chrome.google.com/webstore/detail/ghostery-%E2%80%93-privacy-ad-blo/mlomiejdfkolichcflejclcbmpeaniij?hl=en)|| Block ads, stop trackers and speed up websites.| 
 |[Hunter - Email Finder Extension](https://chrome.google.com/webstore/detail/hunter-email-finder-exten/hgmhmanijnjhaffoampdlllchpolkdnj)|| Find email addresses from anywhere on the web, with just one click.|
-|[Instant Data Scraper](https://chrome.google.com/webstore/detail/instant-data-scraper/ofaokhiedipichpaobibbnahnkdoiiah)|| Instant Data Scraper extracts data from web pages and exports it as Excel or CSV files|
-|[IP Address and Domain Information](https://chrome.google.com/webstore/detail/ip-address-and-domain-inf/lhgkegeccnckoiliokondpaaalbhafoa)||  See detailed information about every IP Address, Domain Name and Provider.|
-|[Mitaka](https://chrome.google.com/webstore/detail/mitaka/bfjbejmeoibbdpfdbmbacmefcbannnbg?hl=en)|| extension for searching IP, domain, URL, hash, etc. via the context menu.|
-|[Save to Pocket](https://chrome.google.com/webstore/detail/save-to-pocket/niloccemoadcdkdjlinkgdfekeahmflj)|| The easiest, fastest way to capture articles, videos, and more.|
+|[Instant Data Scraper](https://chrome.google.com/webstore/detail/instant-data-scraper/ofaokhiedipichpaobibbnahnkdoiiah)|| Instant Data Scraper extracts data from web pages and exports it as Excel or CSV files| 
+|[IP Address and Domain Information](https://chrome.google.com/webstore/detail/ip-address-and-domain-inf/lhgkegeccnckoiliokondpaaalbhafoa)||  See detailed information about every IP Address, Domain Name and Provider.| 
+|[Mitaka](https://chrome.google.com/webstore/detail/mitaka/bfjbejmeoibbdpfdbmbacmefcbannnbg?hl=en)|| extension for searching IP, domain, URL, hash, etc. via the context menu.| 
+|[Save to Pocket](https://chrome.google.com/webstore/detail/save-to-pocket/niloccemoadcdkdjlinkgdfekeahmflj)|| The easiest, fastest way to capture articles, videos, and more.| 
 |[Simplescraper — a fast and free web scraper](https://chrome.google.com/webstore/detail/simplescraper-%E2%80%94-a-fast-an/lnddbhdmiciimpkbilgpklcglkdegdkg)|| Scrape website data and table data in seconds|
-|[Sputnik](https://chrome.google.com/webstore/detail/sputnik/manapjdamopgbpimgojkccikaabhmocd)|| quickly and easily search IPs, Domains, File Hashes, and URLs|
-|[Unpaywall](https://chrome.google.com/webstore/detail/unpaywall/iplffkdpngmdjhlpjmppncnlhomiipha)|| for accessing articles that are available elsewhere for free.|
-|[Wappalyzer](https://addons.mozilla.org/en-US/firefox/addon/wappalyzer/)|| Helpful in identifying technologies on websites.|
-|[Scan WP - WordPress Theme and Plugin Detector](https://chrome.google.com/webstore/detail/scan-wp-wordpress-theme-a/jgepgcdhakjacecafilmhdnifekocmcl)|| Detects what theme and plugins are used in the Wordpress website|
+|[Sputnik](https://chrome.google.com/webstore/detail/sputnik/manapjdamopgbpimgojkccikaabhmocd)|| quickly and easily search IPs, Domains, File Hashes, and URLs| 
+|[Unpaywall](https://chrome.google.com/webstore/detail/unpaywall/iplffkdpngmdjhlpjmppncnlhomiipha)|| for accessing articles that are available elsewhere for free.| 
+|[Wappalyzer](https://addons.mozilla.org/en-US/firefox/addon/wappalyzer/)|| Helpful in identifying technologies on websites.| 
+|[Scan WP - WordPress Theme and Plugin Detector](https://chrome.google.com/webstore/detail/scan-wp-wordpress-theme-a/jgepgcdhakjacecafilmhdnifekocmcl)|| Detects what theme and plugins are used in the Wordpress website| 
 |[Fake Profile Detector (Deepfake, GAN)](https://chrome.google.com/webstore/detail/fake-profile-detector-dee/jbpcgcnnhmjmajjkgdaogpgefbnokpcc)|| Detects if that image contains a GAN generated or real person!|
-|[Screenshot YouTube](https://chrome.google.com/webstore/detail/screenshot-youtube/gjoijpfmdhbjkkgnmahganhoinjjpohk)|| Take a screenshot of any YouTube video with one click.|
-|[Canvas Fingerprint Defender](https://chrome.google.com/webstore/detail/canvas-fingerprint-defend/lanfdkkpgfjfdikkncbnojekcppdebfp)|| Lets you easily hide your real canvas fingerprint by reporting a random fake value.|
-|[Chaff](https://chrome.google.com/webstore/detail/chaff/jgjhamliocfhehbocekgcddfjpgdjnje)|| Generate random web browsing traffic to obfuscate actual browsing behavior to avoid profiling through 3rd party observation.|
-|[ClearURLs](https://chrome.google.com/webstore/detail/clearurls/lckanjgmijmafbedllaakclkaicjfmnk)|| Automatically remove tracking elements from URLs to help protect your privacy when browse through the Internet.|
+|[Screenshot YouTube](https://chrome.google.com/webstore/detail/screenshot-youtube/gjoijpfmdhbjkkgnmahganhoinjjpohk)|| Take a screenshot of any YouTube video with one click.| 
+|[Canvas Fingerprint Defender](https://chrome.google.com/webstore/detail/canvas-fingerprint-defend/lanfdkkpgfjfdikkncbnojekcppdebfp)|| Lets you easily hide your real canvas fingerprint by reporting a random fake value.| 
+|[Chaff](https://chrome.google.com/webstore/detail/chaff/jgjhamliocfhehbocekgcddfjpgdjnje)|| Generate random web browsing traffic to obfuscate actual browsing behavior to avoid profiling through 3rd party observation.| 
+|[ClearURLs](https://chrome.google.com/webstore/detail/clearurls/lckanjgmijmafbedllaakclkaicjfmnk)|| Automatically remove tracking elements from URLs to help protect your privacy when browse through the Internet.| 
 |[Location Guard](https://chrome.google.com/webstore/detail/location-guard/cfohepagpmnodfdmjliccbbigdkfcgia)|| Hide your geographic location from websites.|
-|[Decentraleyes](https://chrome.google.com/webstore/detail/decentraleyes/ldpochfccmkkmhdbclfhpagapcfdljkj)|| Protects you against tracking through "free", centralized, content delivery.|
+|[Decentraleyes](https://chrome.google.com/webstore/detail/decentraleyes/ldpochfccmkkmhdbclfhpagapcfdljkj)|| Protects you against tracking through "free", centralized, content delivery.| 
 |[Netcraft Extension](https://addons.mozilla.org/en-US/firefox/addon/netcraft-toolbar/)|| Provides comprehensive site information and protection from phishing and malicious JavaScript when browsing the web|
-|[Image Downloader - Save photos and pictures](https://chrome.google.com/webstore/detail/image-downloader-save-pho/lbohagbplppjcpllnhdichjldhfgkicb)|| Find, choose and download images you need from any web pages or select all to bulk image download.|
+|[Image Downloader - Save photos and pictures](https://chrome.google.com/webstore/detail/image-downloader-save-pho/lbohagbplppjcpllnhdichjldhfgkicb)|| Find, choose and download images you need from any web pages or select all to bulk image download.| 
 |[L.O.C](https://chrome.google.com/webstore/detail/loc/eojdckfcadamkapabechhbnkleligand)|| collection of tools to help Facebook users with a downloading content and analysis.|
-|[Return YouTube Comment Username](https://chrome.google.com/webstore/detail/return-youtube-comment-us/kamibelompadnaekbellinmgbphoidmj)|| Replaces the "handle" in the YouTube comments section to user name|
-|[TikNote: Video Downloader and Saver](https://chrome.google.com/webstore/detail/tiknote-video-downloader/jilgamolkonoalagcpgjjijaclacillb)|| Download TikTok™ videos without watermark.|
+|[Return YouTube Comment Username](https://chrome.google.com/webstore/detail/return-youtube-comment-us/kamibelompadnaekbellinmgbphoidmj)|| Replaces the "handle" in the YouTube comments section to user name| 
+|[TikNote: Video Downloader and Saver](https://chrome.google.com/webstore/detail/tiknote-video-downloader/jilgamolkonoalagcpgjjijaclacillb)|| Download TikTok™ videos without watermark.| 
 |[TT Downloader](https://chrome.google.com/webstore/detail/tt-downloader/blbckhiepgpniilpmlionnkjoeehhgao?hl=en-GB)|| Download Tik tok Videos and Mass Downloads|
-|[Video Downloader Plus](https://chrome.google.com/webstore/detail/video-downloader-plus/hkdmdpdhfaamhgaojpelccmeehpfljgf)|| The fastest and easiest way to download any video from any website.|
-|[Uniform Timezone Extension](https://chrome.google.com/webstore/detail/uniform-timezone-extensio/fhpdgikedeljapdckiegnjiendkhphlg)|| Brings standardization to social media posts' dates and times.|
-|[Linkclump](https://chrome.google.com/webstore/detail/linkclump/lfpjkncokllnfokkgpkobnkbkmelfefj)|| Lets you open, copy or bookmark multiple links at the same time.|
-|[OpenLink Structured Data Sniffer](https://chrome.google.com/webstore/detail/openlink-structured-data/egdaiaihbdoiibopledjahjaihbmjhdj)|| Reveals structured metadata (Microdata, RDFa, JSON-LD, Turtle, etc.) embedded within HTML documents.|
+|[Video Downloader Plus](https://chrome.google.com/webstore/detail/video-downloader-plus/hkdmdpdhfaamhgaojpelccmeehpfljgf)|| The fastest and easiest way to download any video from any website.| 
+|[Uniform Timezone Extension](https://chrome.google.com/webstore/detail/uniform-timezone-extensio/fhpdgikedeljapdckiegnjiendkhphlg)|| Brings standardization to social media posts' dates and times.| 
+|[Linkclump](https://chrome.google.com/webstore/detail/linkclump/lfpjkncokllnfokkgpkobnkbkmelfefj)|| Lets you open, copy or bookmark multiple links at the same time.| 
+|[OpenLink Structured Data Sniffer](https://chrome.google.com/webstore/detail/openlink-structured-data/egdaiaihbdoiibopledjahjaihbmjhdj)|| Reveals structured metadata (Microdata, RDFa, JSON-LD, Turtle, etc.) embedded within HTML documents.| 
 |[Link Gopher](https://chrome.google.com/webstore/detail/link-gopher/bpjdkodgnbfalgghnbeggfbfjpcfamkf)|| Extracts all links from web page, sorts them, removes duplicates, and displays them in a new tab for copy and paste into other systems.|
-|[Page Monitor](https://chrome.google.com/webstore/detail/page-monitor/ogeebjpdeabhncjpfhgdibjajcajepgg)|| Stays in the background and monitors web pages for changes.|
-|[Pulsedive Threat Intelligence](https://chrome.google.com/webstore/detail/pulsedive-threat-intellig/gdbemlfgncdmmljmkkcemfedbbfgghcp)|| Highlight IPs, domains, and URLs on any website to enrich them using Pulsedive's free threat intelligence data set.|
+|[Page Monitor](https://chrome.google.com/webstore/detail/page-monitor/ogeebjpdeabhncjpfhgdibjajcajepgg)|| Stays in the background and monitors web pages for changes.| 
+|[Pulsedive Threat Intelligence](https://chrome.google.com/webstore/detail/pulsedive-threat-intellig/gdbemlfgncdmmljmkkcemfedbbfgghcp)|| Highlight IPs, domains, and URLs on any website to enrich them using Pulsedive's free threat intelligence data set.| 
 |[Save Page WE](https://chrome.google.com/webstore/detail/save-page-we/dhhpefjklgkmgeafimnjhojgjamoafof)|| Save a complete web page (as curently displayed) as a single HTML file that can be opened in any browser.|
 |[ThreatPinch Lookup](https://chrome.google.com/webstore/detail/threatpinch-lookup/ljdgplocfnmnofbhpkjclbefmjoikgke)|| Add threat intelligence hover tool tips. IPv4, MD5, SHA2, CVE, FQDN or add your own ThreatIntel IOC. Use any REST API.|
-|[Web Archives](https://chrome.google.com/webstore/detail/web-archives/hkligngkgcpcolhcnkgccglchdafcnao)|| View archived and cached versions of web pages on 10+ search engines, such as the Wayback Machine, Archive.is and Google.|
-|[Nimbus Screenshot & Screen Video Recorder](https://chrome.google.com/webstore/detail/nimbus-screenshot-screen/bpconcjcammlapcogcnnelfmaeghhagj)|| Screen Capture FULL Web page or any part. Edit screenshots. Record screencasts - record video from your screen.|
+|[Web Archives](https://chrome.google.com/webstore/detail/web-archives/hkligngkgcpcolhcnkgccglchdafcnao)|| View archived and cached versions of web pages on 10+ search engines, such as the Wayback Machine, Archive.is and Google.| 
+|[Nimbus Screenshot & Screen Video Recorder](https://chrome.google.com/webstore/detail/nimbus-screenshot-screen/bpconcjcammlapcogcnnelfmaeghhagj)|| Screen Capture FULL Web page or any part. Edit screenshots. Record screencasts - record video from your screen.| 
 |[FOCA Files Finder](https://chrome.google.com/webstore/detail/foca-files-finder/mhobefinhafbleanihidiifaedcceoij)|| Scans for available files for a website and provide with the download link for analyzing locally.
 
 **Firefox Extensions**
 
-| Name |      | Description                |
-| :-------- | :------- | :------------------------- |
-|[Multi-Account Containers](https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers/)|| Allows you to open tabs which are completely isolated from each other and don't share the same cookies, session data, or other information.|
+| Name |      | Description                | 
+| :-------- | :------- | :------------------------- | 
+|[Multi-Account Containers](https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers/)|| Allows you to open tabs which are completely isolated from each other and don't share the same cookies, session data, or other information.| 
 |[FireShot: Full Web Page Screenshots](https://addons.mozilla.org/en-US/firefox/addon/fireshot/)|| Allows you to capture and save the visible part, a selected area of the page or the full web page, including parts that are not visible.|
-|[uBlock Origin](https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/)|| Helps in enhancing security of the browser by blocking ads, trackers, and malware sites.|
-|[DownThemAll!](https://addons.mozilla.org/en-US/firefox/addon/downthemall/)|| Allows you to download all media, like videos and images, from a website and save them on your computer.|
-|[ScrapBee](https://addons.mozilla.org/en-US/firefox/addon/scrapbee/)|| Allows you to save entire web pages for offline access and allowing them to organize for a good overview.|
-|[Search by Image](https://addons.mozilla.org/en-US/firefox/addon/search_by_image/)|| Allows you to conduct a reverse image search on multiple databases (like Google, Bing, Yandex, TinEye, SauceNAO, IQDB) at the same time by right-clicking on the image on the website.|
+|[uBlock Origin](https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/)|| Helps in enhancing security of the browser by blocking ads, trackers, and malware sites.| 
+|[DownThemAll!](https://addons.mozilla.org/en-US/firefox/addon/downthemall/)|| Allows you to download all media, like videos and images, from a website and save them on your computer.| 
+|[ScrapBee](https://addons.mozilla.org/en-US/firefox/addon/scrapbee/)|| Allows you to save entire web pages for offline access and allowing them to organize for a good overview.| 
+|[Search by Image](https://addons.mozilla.org/en-US/firefox/addon/search_by_image/)|| Allows you to conduct a reverse image search on multiple databases (like Google, Bing, Yandex, TinEye, SauceNAO, IQDB) at the same time by right-clicking on the image on the website.| 
 |[User-Agent Switcher and Manager](https://addons.mozilla.org/en-US/firefox/addon/user-agent-string-switcher/)|| Allows you to alter your user-agent string to indicate you’re on a different device.|
-|[NoScript Security Suite](https://addons.mozilla.org/en-US/firefox/addon/noscript/)|| Allow potentially malicious web content to run only from sites you trust.|
-|[Privacy Badger](https://addons.mozilla.org/en-US/firefox/addon/privacy-badger17/)|| Allows to block invisible trackers automatically.|
-|[Cookie AutoDelete](https://addons.mozilla.org/en-US/firefox/addon/cookie-autodelete/)|| Allows you to control your cookies.|
-|[Shodan](https://addons.mozilla.org/en-US/firefox/addon/shodan-addon/)|| Tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.|
+|[NoScript Security Suite](https://addons.mozilla.org/en-US/firefox/addon/noscript/)|| Allow potentially malicious web content to run only from sites you trust.| 
+|[Privacy Badger](https://addons.mozilla.org/en-US/firefox/addon/privacy-badger17/)|| Allows to block invisible trackers automatically.| 
+|[Cookie AutoDelete](https://addons.mozilla.org/en-US/firefox/addon/cookie-autodelete/)|| Allows you to control your cookies.| 
+|[Shodan](https://addons.mozilla.org/en-US/firefox/addon/shodan-addon/)|| Tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.| 
 |[Netcraft Extension](https://addons.mozilla.org/en-US/firefox/addon/netcraft-toolbar/)|| Provides comprehensive site information and protection from phishing and malicious JavaScript when browsing the web|
-|[Wappalyzer](https://addons.mozilla.org/en-US/firefox/addon/wappalyzer/)|| Helpful in identifying technologies on websites.|
-|[PastPage](https://addons.mozilla.org/en-US/firefox/addon/pastpage-query-10-web-archives/)|| Helps recover broken or changed pages by querying the Wayback Machine and other web archives in parallel.|
+|[Wappalyzer](https://addons.mozilla.org/en-US/firefox/addon/wappalyzer/)|| Helpful in identifying technologies on websites.| 
 |[Wayback Machine](https://addons.mozilla.org/en-US/firefox/addon/wayback-machine_new/)|| Allows to go back in time to see how a website has changed through the history of the Web.|
 
 ## Credits -

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ https://www.youtube.com/watch?v=ekXS3y_s8k8
 |[FireShot](https://chrome.google.com/webstore/detail/take-webpage-screenshots/mcbpblocgmgfnpjjppndjkmgjaogfceg?hl=en-US)|| Allows you to quickly take a screenshot of a web page in full screen mode.| 
 |[Nimbus Screenshot & Screen Video Recorder](https://chrome.google.com/webstore/detail/nimbus-screenshot-screen/bpconcjcammlapcogcnnelfmaeghhagj)|| Helpful for taking screenshots and video recording web pages.| 
 |[Go Back in Time](https://chrome.google.com/webstore/detail/go-back-in-time/hgdahcpipmgehmaaankiglanlgljlakj)|| Allows you to view an archived version of a web page.| 
+|[PastPage](https://chromewebstore.google.com/detail/pastpage-query-10+-web-ar/icpegbecignmplpkjjcegmjmfadpcpoo)|| Helps recover broken or changed pages by querying the Wayback Machine and other web archives in parallel.|
 |[The Wayback Machine](https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak)|| Extension of the Internet Archive| 
 |[Web Cache Viewer](https://chrome.google.com/webstore/detail/web-cache-viewer/pbkloffickinnlnmefmjmjbacohecpbd)|| lets you right-click on any link or page to view the Wayback Machine or Google Cache versions of that page.| 
 |[Blockchain.info](https://chrome.google.com/webstore/detail/blockchaininfo-address-se/aipmpbhchlkopmpoaipbelfpniojcnkb)|| Helps to find info on bitcoin address.| 
@@ -173,6 +174,7 @@ https://www.youtube.com/watch?v=ekXS3y_s8k8
 |[Shodan](https://addons.mozilla.org/en-US/firefox/addon/shodan-addon/)|| Tells you where the website is hosted (country, city), who owns the IP and what other services/ ports are open.| 
 |[Netcraft Extension](https://addons.mozilla.org/en-US/firefox/addon/netcraft-toolbar/)|| Provides comprehensive site information and protection from phishing and malicious JavaScript when browsing the web|
 |[Wappalyzer](https://addons.mozilla.org/en-US/firefox/addon/wappalyzer/)|| Helpful in identifying technologies on websites.| 
+|[PastPage](https://addons.mozilla.org/en-US/firefox/addon/pastpage-query-10-web-archives/)|| Helps recover broken or changed pages by querying the Wayback Machine and other web archives in parallel.|
 |[Wayback Machine](https://addons.mozilla.org/en-US/firefox/addon/wayback-machine_new/)|| Allows to go back in time to see how a website has changed through the history of the Web.|
 
 ## Credits -


### PR DESCRIPTION
Adds PastPage to the Chrome and Firefox extension tables. PastPage helps OSINT researchers recover broken or changed pages by querying the Wayback Machine and other web archives in parallel.\n\nDisclosure: I maintain PastPage.