### PR TITLE
Add two YouTube extensions: transcript export and comment search

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ https://www.youtube.com/watch?v=ekXS3y_s8k8
 |[Netcraft Extension](https://addons.mozilla.org/en-US/firefox/addon/netcraft-toolbar/)|| Provides comprehensive site information and protection from phishing and malicious JavaScript when browsing the web|
 |[Wappalyzer](https://addons.mozilla.org/en-US/firefox/addon/wappalyzer/)|| Helpful in identifying technologies on websites.| 
 |[Wayback Machine](https://addons.mozilla.org/en-US/firefox/addon/wayback-machine_new/)|| Allows to go back in time to see how a website has changed through the history of the Web.|
+|[YouTube Transcript by Summarizer.tube](https://chromewebstore.google.com/detail/cemgnplbpjphbpknflpmjhmjhaheiane)|| Pulls the full transcript of a YouTube video, including auto-generated captions, and exports it as TXT, SRT, VTT or Markdown for keyword searching and archiving.| 
+|[YouTube Comment Search by Summarizer.tube](https://chromewebstore.google.com/detail/iggebnnaeajeepbkiflohojdlippnicp)|| Loads every comment on a video (not just the first page) and searches them by keyword or by author — useful when a single comment is the lead.| 
 
 ## Credits -
 - [OSINT Browser Extension](https://github.com/cqcore/OSINT-Browser-Extensions)


### PR DESCRIPTION
Two rows appended to the Chrome Extension table.

**YouTube Transcript** — pulls the full transcript of a video, auto-generated captions included, and exports TXT / SRT / VTT / Markdown. The OSINT use is the export: once the speech is text, it is greppable and archivable, which a video is not.

**YouTube Comment Search** — loads *every* comment on a video rather than the first page, then searches by keyword or by author. Verified on a video with 8106 comments. The list already has "Return YouTube Comment Username", which solves the neighbouring problem of handles vs display names.

Both are free, work without an account, and do not require a login to the site.

Disclosure: I'm the maker of both.